### PR TITLE
Fix #71: QRCode is partially hidden on "send" screen for low-res device

### DIFF
--- a/app/src/main/res/layout/activity_receive.xml
+++ b/app/src/main/res/layout/activity_receive.xml
@@ -5,125 +5,130 @@
     android:background="@color/primary_dark"
     android:orientation="vertical">
 
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="20dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:paddingBottom="20dp"
-        android:background="@color/primary"
-        android:focusable="false"
-        android:elevation="2dp">
 
+
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content">
         <LinearLayout
-            android:orientation="horizontal"
+            android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            >
+            android:layout_gravity="center_horizontal"
+            android:gravity="center_horizontal"
+            android:layout_centerVertical="true"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_marginBottom="10dp">
 
-            <EditText
-                android:layout_weight="4"
-                android:layout_width="0dp"
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="number|numberDecimal"
-                android:digits="0123456789."
-                android:ems="10"
-                android:id="@+id/amountBTC"
-                android:hint="0.0000"
-                android:layout_marginRight="8dp"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:maxLength="17"
-                />
+                android:paddingTop="20dp"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:paddingBottom="20dp"
+                android:background="@color/primary"
+                android:focusable="false"
+                android:elevation="2dp">
 
-            <TextView
-                android:layout_weight="3"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:text="BTC-USD"
-                android:gravity="center_horizontal"
-                android:textAlignment="gravity"
-                android:id="@+id/fiatSymbol" />
+                <LinearLayout
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    >
 
-            <EditText
-                android:layout_weight="4"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:inputType="number|numberDecimal"
-                android:digits="0123456789."
-                android:ems="10"
-                android:id="@+id/amountFiat"
-                android:hint="0.00"
-                android:layout_marginLeft="8dp"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:maxLength="17"
-                />
+                    <EditText
+                        android:layout_weight="4"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:inputType="number|numberDecimal"
+                        android:digits="0123456789."
+                        android:ems="10"
+                        android:id="@+id/amountBTC"
+                        android:hint="0.0000"
+                        android:layout_marginRight="8dp"
+                        android:textAppearance="?android:attr/textAppearanceMedium"
+                        android:maxLength="17"
+                        />
 
-        </LinearLayout>
+                    <TextView
+                        android:layout_weight="3"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:attr/textAppearanceMedium"
+                        android:text="BTC-USD"
+                        android:gravity="center_horizontal"
+                        android:textAlignment="gravity"
+                        android:id="@+id/fiatSymbol" />
 
-    </LinearLayout>
+                    <EditText
+                        android:layout_weight="4"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:inputType="number|numberDecimal"
+                        android:digits="0123456789."
+                        android:ems="10"
+                        android:id="@+id/amountFiat"
+                        android:hint="0.00"
+                        android:layout_marginLeft="8dp"
+                        android:textAppearance="?android:attr/textAppearanceMedium"
+                        android:maxLength="17"
+                        />
 
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:gravity="center_horizontal"
-        android:layout_centerVertical="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp">
+                </LinearLayout>
 
-        <ImageView
-            android:id="@+id/qr"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
-            android:layout_marginTop="5dp"
-            />
+            </LinearLayout>
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/text_secondary"
-            android:textSize="16sp"
-            android:paddingLeft="75dp"
-            android:paddingTop="20dp"
-            android:layout_gravity="left"
-            android:fontFamily="Roboto Regular"
-            android:text="@string/segwit_address"
-            android:textStyle="bold"
-            />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:orientation="horizontal"
-            android:paddingTop="5dp"
-            android:layout_height="wrap_content">
-
-            <Switch
-                android:id="@+id/segwit"
+            <ImageView
+                android:id="@+id/qr"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingLeft="22dp"
-                android:checked="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginTop="5dp"
                 />
 
             <TextView
                 android:layout_width="wrap_content"
-                android:text="@string/segwit_switch_prompt"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
-                android:paddingRight="22dp"
+                android:textColor="@color/text_secondary"
+                android:textSize="16sp"
+                android:paddingLeft="75dp"
+                android:paddingTop="20dp"
+                android:layout_gravity="left"
+                android:fontFamily="Roboto Regular"
+                android:text="@string/segwit_address"
+                android:textStyle="bold"
+                />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:orientation="horizontal"
                 android:paddingTop="5dp"
-                />
+                android:layout_height="wrap_content">
+
+                <Switch
+                    android:id="@+id/segwit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="22dp"
+                    android:checked="true"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:text="@string/segwit_switch_prompt"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="10dp"
+                    android:paddingRight="22dp"
+                    android:paddingTop="5dp"
+                    />
+
+            </LinearLayout>
 
         </LinearLayout>
-
-    </LinearLayout>
+    </ScrollView>
 
     <RelativeLayout
         android:orientation="vertical"


### PR DESCRIPTION
Layout slightly modified to enable enable vertical scrolling on low-res device

It would be safe to test this modification on normal device.
Screenshots of new scrolling layout below
![scroll1](https://user-images.githubusercontent.com/1021797/33445866-8688cf9a-d5fe-11e7-87f1-78ce53514d4e.png)
![scroll2](https://user-images.githubusercontent.com/1021797/33445869-88dfb434-d5fe-11e7-8a08-c18e5262b7d5.png)
