### PR TITLE
README: Fix 404 on features list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Features:
 
-[Samourai Wallet features list](https://github.com/Samourai-Wallet/Samourai-Wallet-features.md)
+[Samourai Wallet features list](Samourai-Wallet-features.md)
 
 ### Build:
 


### PR DESCRIPTION
This resolves an issue in the repository README, where-in the first link
displayed 404s. The link has been updated from a broken absolute link to
a relative link in order to resolve the issue.

Before/After:

![screen recording 2018-07-25 at 15 06](https://user-images.githubusercontent.com/1130872/43227677-9f2ab166-901c-11e8-8877-c67121ca2285.gif)
