### PR TITLE
reordering repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
         maven { url 'https://dl.bintray.com/magnusja/maven' }
-        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -16,10 +16,10 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url 'https://dl.bintray.com/magnusja/maven' }
         maven { url 'https://jitpack.io' }
-        google()
         mavenLocal()
     }
 }


### PR DESCRIPTION
I got build failure and I found that the order of the repositories matters.

https://stackoverflow.com/questions/46972122/could-not-find-com-android-tools-lintlint-gradle-android-studio-3

build passes for me now