### PR TITLE
Language switch implementation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
         tools:node="replace" />
 
     <application
-        android:name="android.support.multidex.MultiDexApplication"
+        android:name=".language.App"
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/samourai/wallet/SettingsActivity2.java
+++ b/app/src/main/java/com/samourai/wallet/SettingsActivity2.java
@@ -109,6 +109,21 @@ public class SettingsActivity2 extends PreferenceActivity	{
                     }
                 });
 
+                final CheckBoxPreference cbLanguage = (CheckBoxPreference) findPreference("systemLanguage");
+                cbLanguage.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                    public boolean onPreferenceChange(Preference preference, Object newValue) {
+
+                        if (cbLanguage.isChecked()) {
+                            PrefsUtil.getInstance(SettingsActivity2.this).setValue(PrefsUtil.USE_SYSTEM_LANGUAGE, false);
+                        }
+                        else    {
+                            PrefsUtil.getInstance(SettingsActivity2.this).setValue(PrefsUtil.USE_SYSTEM_LANGUAGE, true);
+                        }
+                        Toast.makeText(getApplicationContext(), R.string.options_restartRequired, Toast.LENGTH_LONG).show();
+                        return true;
+                    }
+                });
+
             }
             else if(strBranch.equals("txs"))   {
                 addPreferencesFromResource(R.xml.settings_txs);

--- a/app/src/main/java/com/samourai/wallet/language/App.java
+++ b/app/src/main/java/com/samourai/wallet/language/App.java
@@ -1,0 +1,28 @@
+package com.samourai.wallet.language;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.support.multidex.MultiDexApplication;
+
+
+
+// This class is used as Application class for Samourai.
+// It extends MultiDexApplication to support MultiDex and sets the chosen language on start and onConfigurationChanged.
+
+public class App extends MultiDexApplication {
+
+
+    public static LocaleManager localeManager;
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        localeManager = new LocaleManager(base);
+        super.attachBaseContext(localeManager.setLocale(base));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        localeManager.setLocale(this);
+    }
+}

--- a/app/src/main/java/com/samourai/wallet/language/LocaleManager.java
+++ b/app/src/main/java/com/samourai/wallet/language/LocaleManager.java
@@ -1,0 +1,47 @@
+package com.samourai.wallet.language;
+
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.preference.PreferenceManager;
+import android.content.Context;
+import android.content.res.Configuration;
+
+import com.samourai.wallet.SettingsActivity2;
+import com.samourai.wallet.util.PrefsUtil;
+
+import java.util.Locale;
+
+
+public class LocaleManager {
+
+    private final SharedPreferences prefs;
+
+    public LocaleManager(Context context) {
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    public static Context setLocale(Context c) {
+        return updateResources(c, getLanguage(c));
+    }
+
+
+    public static String getLanguage(Context c) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
+        if (prefs.getBoolean("useSystemLanguage", true)) {
+            return Resources.getSystem().getConfiguration().locale.getLanguage();
+        }
+        else    {
+            return "en";
+        }
+    }
+
+    private static Context updateResources(Context context, String language) {
+        Locale locale = new Locale(language);
+        Resources res = context.getResources();
+        Configuration config = new Configuration(res.getConfiguration());
+        config.setLocale(locale);
+        res.updateConfiguration(config, res.getDisplayMetrics());
+        return context;
+    }
+
+}

--- a/app/src/main/java/com/samourai/wallet/util/PrefsUtil.java
+++ b/app/src/main/java/com/samourai/wallet/util/PrefsUtil.java
@@ -50,6 +50,7 @@ public class PrefsUtil {
 	public static final String PAYNYM_FEATURED_SEGWIT = "paynymFeatured_v1";
 	public static final String IS_RESTORE = "isRestore";
 	public static final String HAPTIC_PIN = "hapticPin";
+	public static final String USE_SYSTEM_LANGUAGE = "useSystemLanguage";
 
 	private static Context context = null;
 	private static PrefsUtil instance = null;

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,7 +21,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Abbrechen</string>
 
-    <string name="options_cat_prefs">Block-Explorer</string>
+    <string name="options_cat_prefs">Voreinstellungen</string>
     <string name="options_cat_stealth">Unsichtbar-Modus</string>
     <string name="options_cat_remote">Fernzugriff</string>
     <string name="options_cat_wallet">Wallet</string>
@@ -593,6 +593,11 @@
     <string name="request_amount">Angeforderter Betrag</string>
     <string name="address_type">Addresstyp</string>
     <string name="path">Pfad</string>
+
+
+    <string name="options_language">Systemsprache verwenden</string>
+    <string name="options_language2">Deaktivieren um Englisch zu verwenden</string>
+    <string name="options_restartRequired">Diese Änderung wird erst nach einem Neustart der App wirksam.</string>
 	
 	
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
 
-    <string name="options_cat_prefs">Block explorer</string>
+    <string name="options_cat_prefs">Preferences</string>
     <string name="options_cat_stealth">Stealth</string>
     <string name="options_cat_remote">Remote</string>
     <string name="options_cat_wallet">Wallet</string>
@@ -632,5 +632,9 @@
     <string name="hide_log">HIDE LOG</string>
     <string name="copy">Copy</string>
     <string name="show_log">Show Log</string>
+
+    <string name="options_language">Use system language</string>
+    <string name="options_language2">Uncheck to use english</string>
+    <string name="options_restartRequired">This change takes effect after a restart of the app.</string>
 
 </resources>

--- a/app/src/main/res/xml/settings_prefs.xml
+++ b/app/src/main/res/xml/settings_prefs.xml
@@ -7,4 +7,11 @@
         android:key="explorer"
         />
 
+    <CheckBoxPreference
+        android:title="@string/options_language"
+        android:summary="@string/options_language2"
+        android:defaultValue="true"
+        android:key="systemLanguage"
+        />
+
 </PreferenceScreen>


### PR DESCRIPTION
Hi, this PR enables switching between english and the system language. Default is system language.

Motivation:
1. It is easier to make tutorials for a broad audience, if you can switch to english.
2. Some people might prefer english.
3. If you are not sure what a functionality exactly does it is sometimes hard to google. Switching to english helps to get the correct search words.

Notes:
The change of the language will only be applied on restart of the app. A toast message notifies the user about this.
Changing the language on runtime is possible but actually quite complex and I didn't want to interfere with the already written code that much. Therefore I decided a restart is the better option.