### PR TITLE
Removed references to "Currency" in localized strings.xml files (options_cat_prefs)

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -20,7 +20,7 @@
     <string name="ok">Добре</string>
     <string name="cancel">Отказ</string>
 
-    <string name="options_cat_prefs">Валута, Block explorer</string>
+    <string name="options_cat_prefs">Block explorer</string>
     <string name="options_cat_stealth">Прикритост</string>
     <string name="options_cat_remote">Дистанционно управление</string>
     <string name="options_cat_wallet">Портфейл</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -20,7 +20,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Cancelar</string>
 
-    <string name="options_cat_prefs">Moeda, Explorador de blocos</string>
+    <string name="options_cat_prefs">Explorador de blocos</string>
     <string name="options_cat_stealth">Furtividade</string>
     <string name="options_cat_remote">Controle Remoto</string>
     <string name="options_cat_wallet">Carteira</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,7 +20,7 @@
     <string name="ok">Aceptar</string>
     <string name="cancel">Cancelar</string>
 
-    <string name="options_cat_prefs">Moneda, Explorador de bloques</string>
+    <string name="options_cat_prefs">Explorador de bloques</string>
     <string name="options_cat_stealth">Invisibilidad</string>
     <string name="options_cat_remote">Control remoto</string>
     <string name="options_cat_wallet">Billetera</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,7 +20,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Annuler</string>
 
-    <string name="options_cat_prefs">Monnaie, Explorateur de blocs</string>
+    <string name="options_cat_prefs">Explorateur de blocs</string>
     <string name="options_cat_stealth">Mode furtif</string>
     <string name="options_cat_remote">À distance</string>
     <string name="options_cat_wallet">Portefeuille</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -20,7 +20,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Batal</string>
 
-    <string name="options_cat_prefs">Mata uang, Block explorer</string>
+    <string name="options_cat_prefs">Block explorer</string>
     <string name="options_cat_stealth">Mode Sembunyi</string>
     <string name="options_cat_remote">Remote</string>
     <string name="options_cat_wallet">Wallet</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -20,7 +20,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Annulla</string>
 
-    <string name="options_cat_prefs">Valuta, explorer di blocchi</string>
+    <string name="options_cat_prefs">Explorer di blocchi</string>
     <string name="options_cat_stealth">Modalità segreta</string>
     <string name="options_cat_remote">Controllo Remoto</string>
     <string name="options_cat_wallet">Wallet</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -19,7 +19,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Cancelar</string>
 
-    <string name="options_cat_prefs">Moeda, Explorador de blocos</string>
+    <string name="options_cat_prefs">Explorador de blocos</string>
     <string name="options_cat_stealth">Furtividade</string>
     <string name="options_cat_remote">Controlo Remoto</string>
     <string name="options_cat_wallet">Carteira</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -20,7 +20,7 @@
   <string name="ok">Tamam</string>
   <string name="cancel">İptal</string>
 
-  <string name="options_cat_prefs">Para birimi, Blok gezgini</string>
+  <string name="options_cat_prefs">Blok gezgini</string>
   <string name="options_cat_stealth">Gizlilik</string>
   <string name="options_cat_remote">Uzaktan Erişim</string>
   <string name="options_cat_wallet">Cüzdan</string>


### PR DESCRIPTION
References to "Currency" (i.e. "Currency, Block Explorer) were removed from **options_cat_prefs** across localized translations of strings.xml. 

