### PR TITLE
Remove "first_use_shuffle" from strings.xml and all localizations. 

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -204,8 +204,6 @@
 
     <string name="max_available">Макс. налични:</string>
 
-    <string name="first_use_shuffle">This is your Shifted Account. The Bitcoin you receive through ShapeShift will be stored in this account which does not share the same address space as your primary wallet account.</string>
-
     <string name="select_account">Изберете акаунт</string>
     <string name="received_bitcoin">Получени биткойни</string>
     <string name="received">Получено</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -200,8 +200,6 @@
 
     <string name="max_available">Máx. disponível:</string>
 
-    <string name="first_use_shuffle">Essa é sua Conta Shifted. O Bitcoin recebido através do ShapeShift será armazenado nessa conta que não compartilha do mesmo espaço de endereços que sua carteira primária.</string>
-
     <string name="select_account">Selecionar conta</string>
     <string name="received_bitcoin">Bitcoin recebido</string>
     <string name="received">Recebido</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -204,8 +204,6 @@
 
     <string name="max_available">Max. verfügbar:</string>
 
-    <string name="first_use_shuffle">Dies ist dein Tausch-Account. Bitcoin, die du über ShapeShift erhältst, werden in diesem Account gespeichert. Dieser Account teilt seinen Adressbereich nicht mit deiner primären Wallet.</string>
-
     <string name="select_account">Account wählen</string>
     <string name="received_bitcoin">Empfangene Bitcoin</string>
     <string name="received">Empfangen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -194,8 +194,6 @@
 
     <string name="max_available">Máximo disponible</string>
 
-    <string name="first_use_shuffle">Esta esta tu billetera Shifted. Los bitcoins que recibas mediante ShapeShift se almacenarán en esta dirección que no comparte el espacio de direcciones de tu billetera principal.</string>
-
     <string name="select_account">Elegir cuenta</string>
     <string name="received_bitcoin">Bitcoin recibido</string>
     <string name="received">Recibido</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -197,8 +197,6 @@
 
     <string name="max_available">Max. disponible:</string>
 
-    <string name="first_use_shuffle">Ceci est votre Compte Shift. Les Bitcoin que vous recevez via ShapeShift seront stockés sur ce compte qui ne partage pas d\'espace adresses commun avec le compte principal de votre portefeuille.</string>
-
     <string name="select_account">Sélectionnez votre compte</string>
     <string name="received_bitcoin">Bitcoin Reçus</string>
     <string name="received">Reçus</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -203,8 +203,6 @@
 
     <string name="max_available">Rendelkezésre áll:</string>
 
-    <string name="first_use_shuffle">Ez a Shifted pénztárcád. A Bitcoin, amit ShapeShift-en keresztül kapsz, ebben a pénztárcában lesz tárolva. Ez a pénztárca az elsődleges pénztárcádtól különböző címeket használ.</string>
-
     <string name="select_account">Pénztárca kiválasztása</string>
     <string name="received_bitcoin">Bejövő tranzakció:</string>
     <string name="received">Fogadva:</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -197,8 +197,6 @@
 
     <string name="max_available">Max. tersedia:</string>
 
-    <string name="first_use_shuffle">Ini adalah akun yang anda pindahkan. Bitcoin yang anda terima melalui ShapeShift akan disimpan dalam akun ini, tidak berbagi ruang address yang sama dengan akun utama wallet anda.</string>
-
     <string name="select_account">Pilih akun</string>
     <string name="received_bitcoin">Menerima Bitcoin</string>
     <string name="received">Diterima</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -203,8 +203,6 @@
 
     <string name="max_available">Max. disponibile:</string>
 
-    <string name="first_use_shuffle">Questo è il tuo account Shifted. I Bitcoin ricevuti tramite ShapeShift saranno depositati in questo account che non avrà lo stesso spazio di indirizzi del tuo account principale del wallet.</string>
-
     <string name="select_account">Seleziona account</string>
     <string name="received_bitcoin">Bitcoin ricevuti</string>
     <string name="received">Ricevuti</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -203,8 +203,6 @@
 
     <string name="max_available">Max. beschikbaar:</string>
 
-    <string name="first_use_shuffle">Dit is je Shifted-rekening. De bitcoin die je ontvangt via ShapeShift zal op deze rekening worden opgeslagen, die niet dezelfde adresruimte gebruikt als je standaardrekening.</string>
-
     <string name="select_account">Account selecteren</string>
     <string name="received_bitcoin">Bitcoin ontvangen</string>
     <string name="received">Ontvangen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -191,8 +191,6 @@
 
     <string name="max_available">Máx. disponível:</string>
 
-    <string name="first_use_shuffle">Esta é sua Conta Shifted. As Bitcoins recebidas através do ShapeShift serão guardadas nesta conta que não faz parte do espaço de endereços da sua carteira principal.</string>
-
     <string name="select_account">Selecionar conta</string>
     <string name="received_bitcoin">Bitcoin recebido</string>
     <string name="received">Recebido</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -203,8 +203,6 @@
 
     <string name="max_available">Макс. доступно:</string>
 
-    <string name="first_use_shuffle">Это ваш Shifted-аккаунт. Биткоины, которые вы получили с ShapeShift, будут храниться здесь. Адреса Shifted-аккаунта не будут пересекаться с адресами вашего основного кошелька.</string>
-
     <string name="select_account">Выбрать аккаунт</string>
     <string name="received_bitcoin">Получен перевод</string>
     <string name="received">Получено</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -203,8 +203,6 @@
 
   <string name="max_available">En fazla mümkün:</string>
 
-  <string name="first_use_shuffle">Bu sizin Shifted hesabınız. ShapeShift üzerinden alacağınız Bitcoin\'ler ana cüzdan hesabınız ile aynı adres alanını paylaşmayan bu hesap üzerinde tutulacaktır.</string>
-
   <string name="select_account">Hesap seç</string>
   <string name="received_bitcoin">Alınan Bitcoin</string>
   <string name="received">Alındı</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,8 +203,6 @@
 
     <string name="max_available">Max. available:</string>
 
-    <string name="first_use_shuffle">This is your Shifted Account. The Bitcoin you receive through ShapeShift will be stored in this account which does not share the same address space as your primary wallet account.</string>
-
     <string name="select_account">Select account</string>
     <string name="received_bitcoin">Received Bitcoin</string>
     <string name="received">Received</string>


### PR DESCRIPTION
This PR consists of a series of commits intended to remove "first_use_shuffle" and corresponding text from the main strings.xml file and its various localizations. 

_*Commit 9ac0a3c is mislabelled as "Remove first_use_shuffle from **values-id**/strings". In actuality, it removes "first_use_shuffle" from **values-nl**/strings.xml._ 