### PR TITLE
Fix crash when setting trusted node

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -299,6 +299,7 @@
                 <action android:name="android.net.wifi.WIFI_STATE_CHANGED" />
             </intent-filter>
         </receiver>
+        <uses-library android:name="org.apache.http.legacy" android:required="false"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
With Android 9 and higher "uses-library" is needed in
AndroidManifest.xml to be able to continue to use the Apache HTTP
client.
If not adding the "uses-library" the app will crash when setting
trusted node:
java.lang.NoClassDefFoundError:
Failed resolution of: Lorg/apache/http/impl/client/DefaultHttpClient